### PR TITLE
Visualizing Agent Pose

### DIFF
--- a/mar_bringup/config/visualizer/rviz_configuration.rviz
+++ b/mar_bringup/config/visualizer/rviz_configuration.rviz
@@ -10,6 +10,7 @@ Panels:
         - /MarkerArray1/Topic1
         - /MarkerArray2
         - /MarkerArray3
+        - /Marker1
       Splitter Ratio: 0.5
     Tree Height: 752
   - Class: rviz_common/Selection
@@ -50,7 +51,7 @@ Visualization Manager:
       Plane: XY
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
-      Value: true
+      Value: false
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
       Name: MarkerArray
@@ -86,6 +87,19 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /object_truth/markers
+      Value: true
+    - Class: rviz_default_plugins/Marker
+      Enabled: true
+      Name: Marker
+      Namespaces:
+        /ego: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ego/markers/agent_pose
       Value: true
   Enabled: true
   Global Options:

--- a/mar_viz/mar_viz/nodes.py
+++ b/mar_viz/mar_viz/nodes.py
@@ -263,7 +263,7 @@ class AvstackBridgedVisualizer(Node):
 
     def _agent_pose_init_pub(self, agent_namespace: str):
         """Initialize the publisher and subscriber for an
-        agent's detections
+        agent's pose
 
         Args:
             agent_namespace (str): the agent's namespace
@@ -281,8 +281,9 @@ class AvstackBridgedVisualizer(Node):
         namespace: str,
         color: ColorRGBA,
     ) -> Marker:
-        """Helper Function to convert from a ObjectState
-        object to a Marker ROS2 message
+        """Helper Function to generate a marker for an agent's
+        pose
+        
 
         Args:
             header: the header to use for each Marker object


### PR DESCRIPTION
- visualizer node now publishes a message for {agent_namespace}/markers/agent_pose which contains the agent pose in the agent's reference frame.
- Visualization now shows the agent bose as a yellow bounding box
- updated default rviz configuration to now show agent pose on startup of the ego vehicle